### PR TITLE
Create stylo.excelify.table.R

### DIFF
--- a/stylo.excelify.table.R
+++ b/stylo.excelify.table.R
@@ -1,0 +1,42 @@
+excelify.table <- function(txtfile = "./table_with_frequencies.txt") {
+  # this adds `idx_` as a dummy header to the wordlist table
+  # for an easier import into Excel.
+  # creates a copy of the file, with the suffix `_xl`
+  baseName <- tools::file_path_sans_ext(txtfile)
+  fileExt <- tools::file_ext(txtfile)
+  firstLine <- scan(file = txtfile, what = "list", sep = "\n", n = 1)
+  rest <- scan(file = txtfile, what = "list", sep = "\n", skip = 1)
+  firstLine <- paste("\"idx_\"", firstLine)
+  outFile <- paste0(baseName, "_xl.", fileExt)
+  conn <- file(outFile, "w")
+  writeLines(c(firstLine, rest), con = conn)
+  close(conn)
+}
+
+####################################
+### sed [stream editor] solution ###
+####################################
+#
+# if you have sed installed, running this from the
+# command line is a bit more performant:
+#
+## sed "1 s/^/\"idx_\" /" table_with_frequencies.txt > table_with_frequencies_xl.txt ##
+# 
+## sed's -i flag allows making this change in-place, but this breaks stylo's ability
+## to use the frequencies table.
+#
+
+###########################
+### Excel-only solution ###
+###########################
+#
+# If you'd rather just do this in Excel (which is simplest!):
+# According to Microsoft's docs, this should work on Excel for Windows and
+# Excel for Mac, although I don't have a Mac for verifying that myself.
+#
+# 1. Import the file as usual -- data has headers; delimited on Space
+# 2. Go to cell "A1" (which will almost certainly be selected by default)
+# 3. Press [ CONTROL + SHIFT + = ] to bring up the `Insert Cell` dialog
+# 4. Select [ Shift cells right ]
+# 5. Don't save changes on exit to maintain compatibility with stylo
+#


### PR DESCRIPTION
- A simple implementation using functions available in base R that modifies stylo's output file `table_with_frequencies.txt` to prepend the column header "idx_" to make viewing the file in Excel more straightforward.
- Produces a copy of the file, `table_with_frequencies_xl.txt`, by default, so be mindful of running this with very large datasets.

- Also includes (in a comment below the script) a sample `sed` script for editing stylo's output file `table_with_frequencies.txt` from the command line, if that's more your cup of tea.
- Also includes keyboard shortcut directions for quickly shifting the header row from within Excel.